### PR TITLE
only backup dir if -r/-R specify

### DIFF
--- a/2/newrm
+++ b/2/newrm
@@ -21,12 +21,14 @@ fi
 # Parse all options looking for '-f'
 
 flags=""
+recursive="off"
 
 while getopts "dfiPRrvW" opt
 do
   case $opt in
     f ) exec $realrm "$@"     ;;  # exec lets us exit this script directly.
-    * ) flags="$flags -$opt"  ;;  # other flags are for 'rm', not us
+		r | R ) recursive="on"    ;&
+    * ) flags="$flags -$opt"  ;;&  # other flags are for 'rm', not us
   esac
 done
 shift $(( $OPTIND - 1 ))
@@ -48,8 +50,10 @@ fi
 for arg 
 do
   newname="$archivedir/$(date "+%S.%M.%H.%d.%m").$(basename "$arg")"
-  if [ -f "$arg" -o -d “$arg” ] ; then
+  if [ -f "$arg" ] ; then
     $copy "$arg" "$newname"	
+	elif [  -d "$arg" ] && [ "$recursive"="on" ]; then
+		$copy "$arg" "$newname"
   fi
 done
 


### PR DESCRIPTION
Hi Brandon, 

Your book is amazing! It's just a small tweak to your newrm script. Only copy(backup) the directory when you run the script with -r/-R, or you will encounter the case that you fail to delete the dir and still backup the directory under ~/.deleted_files

Thanks,
Shawn